### PR TITLE
Optimizing codebase & XSharedPreferences performance

### DIFF
--- a/app/src/main/java/es/chiteroman/bootloaderspoofer/XSpoofBl.java
+++ b/app/src/main/java/es/chiteroman/bootloaderspoofer/XSpoofBl.java
@@ -347,19 +347,7 @@ public final class XSpoofBl {
                 teeEnforcedEncodables.add(taggedObject);
             }
 
-            SecureRandom random = new SecureRandom();
-
-            byte[] bytes1 = new byte[32];
-            byte[] bytes2 = new byte[32];
-
-            random.nextBytes(bytes1);
-            random.nextBytes(bytes2);
-
-            ASN1Encodable[] rootOfTrustEncodables = {new DEROctetString(bytes1), ASN1Boolean.TRUE, new ASN1Enumerated(0), new DEROctetString(bytes2)};
-
-            ASN1Sequence rootOfTrustSeq = new DERSequence(rootOfTrustEncodables);
-
-            ASN1TaggedObject rootOfTrust = new DERTaggedObject(true, 704, rootOfTrustSeq);
+            ASN1TaggedObject rootOfTrust = getAsn1TaggedObject();
 
             teeEnforcedEncodables.add(rootOfTrust);
 
@@ -385,6 +373,23 @@ public final class XSpoofBl {
         }
 
         return extension;
+    }
+
+    @NonNull
+    private static ASN1TaggedObject getAsn1TaggedObject() {
+        SecureRandom random = new SecureRandom();
+
+        byte[] bytes1 = new byte[32];
+        byte[] bytes2 = new byte[32];
+
+        random.nextBytes(bytes1);
+        random.nextBytes(bytes2);
+
+        ASN1Encodable[] rootOfTrustEncodables = {new DEROctetString(bytes1), ASN1Boolean.TRUE, new ASN1Enumerated(0), new DEROctetString(bytes2)};
+
+        ASN1Sequence rootOfTrustSeq = new DERSequence(rootOfTrustEncodables);
+
+        return new DERTaggedObject(true, 704, rootOfTrustSeq);
     }
 
     private static Extension createHackedExtensions() {

--- a/app/src/main/java/es/chiteroman/bootloaderspoofer/XSpoofBl.java
+++ b/app/src/main/java/es/chiteroman/bootloaderspoofer/XSpoofBl.java
@@ -7,6 +7,8 @@ import android.content.pm.PackageManager;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 
+import androidx.annotation.NonNull;
+
 import org.bouncycastle.asn1.ASN1Boolean;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
@@ -36,6 +38,7 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -437,20 +440,7 @@ public final class XSpoofBl {
 
             ASN1Encodable[] teeEnforcedEncodables = {purpose, algorithm, keySize, digest, ecCurve, noAuthRequired, creationDateTime, origin, rootOfTrust, osVersion, osPatchLevel};
 
-            ASN1Integer attestationVersion = new ASN1Integer(4);
-            ASN1Enumerated attestationSecurityLevel = new ASN1Enumerated(1);
-            ASN1Integer keymasterVersion = new ASN1Integer(41);
-            ASN1Enumerated keymasterSecurityLevel = new ASN1Enumerated(1);
-            ASN1OctetString attestationChallenge = new DEROctetString(attestationChallengeBytes);
-            ASN1OctetString uniqueId = new DEROctetString("".getBytes());
-            ASN1Sequence softwareEnforced = new DERSequence();
-            ASN1Sequence teeEnforced = new DERSequence(teeEnforcedEncodables);
-
-            ASN1Encodable[] keyDescriptionEncodables = {attestationVersion, attestationSecurityLevel, keymasterVersion, keymasterSecurityLevel, attestationChallenge, uniqueId, softwareEnforced, teeEnforced};
-
-            ASN1Sequence keyDescriptionHackSeq = new DERSequence(keyDescriptionEncodables);
-
-            ASN1OctetString keyDescriptionOctetStr = new DEROctetString(keyDescriptionHackSeq);
+            ASN1OctetString keyDescriptionOctetStr = getAsn1OctetString(teeEnforcedEncodables);
 
             return new Extension(new ASN1ObjectIdentifier("1.3.6.1.4.1.11129.2.1.17"), false, keyDescriptionOctetStr);
 
@@ -458,6 +448,24 @@ public final class XSpoofBl {
 //            XposedBridge.log(t);
         }
         return null;
+    }
+
+    @NonNull
+    private static ASN1OctetString getAsn1OctetString(ASN1Encodable[] teeEnforcedEncodables) throws IOException {
+        ASN1Integer attestationVersion = new ASN1Integer(4);
+        ASN1Enumerated attestationSecurityLevel = new ASN1Enumerated(1);
+        ASN1Integer keymasterVersion = new ASN1Integer(41);
+        ASN1Enumerated keymasterSecurityLevel = new ASN1Enumerated(1);
+        ASN1OctetString attestationChallenge = new DEROctetString(attestationChallengeBytes);
+        ASN1OctetString uniqueId = new DEROctetString("".getBytes());
+        ASN1Sequence softwareEnforced = new DERSequence();
+        ASN1Sequence teeEnforced = new DERSequence(teeEnforcedEncodables);
+
+        ASN1Encodable[] keyDescriptionEncodables = {attestationVersion, attestationSecurityLevel, keymasterVersion, keymasterSecurityLevel, attestationChallenge, uniqueId, softwareEnforced, teeEnforced};
+
+        ASN1Sequence keyDescriptionHackSeq = new DERSequence(keyDescriptionEncodables);
+
+        return new DEROctetString(keyDescriptionHackSeq);
     }
 
     private static Certificate createLeafCert() {

--- a/app/src/main/java/its/madruga/wpp/xposed/XposedMain.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/XposedMain.java
@@ -1,5 +1,7 @@
 package its.madruga.wpp.xposed;
 
+import androidx.annotation.NonNull;
+
 import java.util.HashSet;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
@@ -8,14 +10,20 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 import es.chiteroman.bootloaderspoofer.XSpoofBl;
 import io.github.lsposed.disableflagsecure.XDisableFlagSecure;
+import its.madruga.wpp.BuildConfig;
 import its.madruga.wpp.xposed.plugins.core.XDatabases;
 import its.madruga.wpp.xposed.plugins.core.XMain;
 
 public class XposedMain implements IXposedHookLoadPackage {
+    private static XSharedPreferences pref;
+
+    @NonNull
     public static XSharedPreferences getPref() {
-        XSharedPreferences pref = new XSharedPreferences("its.madruga.wpp");
-        pref.makeWorldReadable();
-        pref.reload();
+        if (pref == null) {
+            pref = new XSharedPreferences(BuildConfig.APPLICATION_ID);
+            pref.makeWorldReadable();
+            pref.reload();
+        }
         return pref;
     }
 
@@ -23,7 +31,7 @@ public class XposedMain implements IXposedHookLoadPackage {
     public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
         var packageName = lpparam.packageName;
         var classLoader = lpparam.classLoader;
-        if (packageName.equals("its.madruga.wpp")) {
+        if (packageName.equals(BuildConfig.APPLICATION_ID)) {
             XposedChecker.setActiveModule(lpparam.classLoader);
         }
 

--- a/app/src/main/java/its/madruga/wpp/xposed/models/XHookBase.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/models/XHookBase.java
@@ -1,5 +1,7 @@
 package its.madruga.wpp.xposed.models;
 
+import androidx.annotation.NonNull;
+
 import de.robv.android.xposed.XSharedPreferences;
 
 public class XHookBase {
@@ -7,7 +9,7 @@ public class XHookBase {
     public final ClassLoader loader;
     public final XSharedPreferences prefs;
 
-    public XHookBase(ClassLoader loader, XSharedPreferences preferences) {
+    public XHookBase(@NonNull ClassLoader loader, @NonNull XSharedPreferences preferences) {
         this.loader = loader;
         this.prefs = preferences;
     }

--- a/app/src/main/java/its/madruga/wpp/xposed/plugins/core/XMain.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/plugins/core/XMain.java
@@ -8,6 +8,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
@@ -19,29 +21,29 @@ import its.madruga.wpp.BuildConfig;
 import its.madruga.wpp.ClassesReference;
 import its.madruga.wpp.listeners.RestartListener;
 import its.madruga.wpp.xposed.plugins.functions.XAntiRevoke;
+import its.madruga.wpp.xposed.plugins.functions.XDndMode;
+import its.madruga.wpp.xposed.plugins.functions.XMediaQuality;
+import its.madruga.wpp.xposed.plugins.functions.XOthers;
+import its.madruga.wpp.xposed.plugins.functions.XShareLimit;
+import its.madruga.wpp.xposed.plugins.functions.XStatusDownload;
+import its.madruga.wpp.xposed.plugins.functions.XViewOnce;
 import its.madruga.wpp.xposed.plugins.personalization.XBioAndName;
 import its.madruga.wpp.xposed.plugins.personalization.XBubbleColors;
 import its.madruga.wpp.xposed.plugins.personalization.XChangeColors;
 import its.madruga.wpp.xposed.plugins.personalization.XChatsFilter;
-import its.madruga.wpp.xposed.plugins.functions.XDndMode;
+import its.madruga.wpp.xposed.plugins.personalization.XSecondsToTime;
 import its.madruga.wpp.xposed.plugins.privacy.XFreezeLastSeen;
 import its.madruga.wpp.xposed.plugins.privacy.XGhostMode;
 import its.madruga.wpp.xposed.plugins.privacy.XHideReceipt;
 import its.madruga.wpp.xposed.plugins.privacy.XHideTag;
 import its.madruga.wpp.xposed.plugins.privacy.XHideView;
-import its.madruga.wpp.xposed.plugins.functions.XMediaQuality;
-import its.madruga.wpp.xposed.plugins.functions.XOthers;
-import its.madruga.wpp.xposed.plugins.personalization.XSecondsToTime;
-import its.madruga.wpp.xposed.plugins.functions.XShareLimit;
-import its.madruga.wpp.xposed.plugins.functions.XStatusDownload;
-import its.madruga.wpp.xposed.plugins.functions.XViewOnce;
 
 public class XMain {
 
     public static Application mApp;
     public static ArrayList<String> list = new ArrayList<>();
 
-    public static void Initialize(ClassLoader loader, XSharedPreferences pref) {
+    public static void Initialize(@NonNull ClassLoader loader, @NonNull XSharedPreferences pref) {
 
         XposedHelpers.findAndHookMethod(Instrumentation.class, "callApplicationOnCreate", Application.class, new XC_MethodHook() {
             protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
@@ -65,7 +67,7 @@ public class XMain {
                     new AlertDialog.Builder((Activity) param.thisObject)
                             .setTitle("Error detected")
                             .setMessage("The following options aren't working:\n\n" + String.join("\n", list.toArray(new String[0])))
-                            .create().show();
+                            .show();
                 }
             }
         });
@@ -73,7 +75,7 @@ public class XMain {
         RestartListener.start(XposedHelpers.findClass(ClassesReference.AutoReboot.autoreboot, loader));
     }
 
-    private static void plugins(ClassLoader loader, XSharedPreferences pref) {
+    private static void plugins(@NonNull ClassLoader loader, @NonNull XSharedPreferences pref) {
         ArrayList<String> loadedClasses = new ArrayList<>();
         var classes = new Class<?>[]{
                 XOthers.class,
@@ -106,7 +108,6 @@ public class XMain {
             } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
                      InstantiationException e) {
                 XposedBridge.log(e);
-                e.printStackTrace();
                 if (e instanceof InvocationTargetException) {
                     list.add(classe.getSimpleName());
                 }

--- a/app/src/main/java/its/madruga/wpp/xposed/plugins/functions/XAntiRevoke.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/plugins/functions/XAntiRevoke.java
@@ -40,14 +40,12 @@ public class XAntiRevoke extends XHookBase {
     @SuppressLint("StaticFieldLeak")
     private static Activity mConversation;
     private static SharedPreferences mShared;
-    public static SharedPreferences mPref;
 
     public XAntiRevoke(ClassLoader loader, XSharedPreferences preferences) {
         super(loader, preferences);
-        mPref = preferences;
     }
 
-    private static void isMRevoked(Object objMessage, TextView dateTextView, String antirevokeType) {
+    private void isMRevoked(Object objMessage, TextView dateTextView, String antirevokeType) {
         var fieldMessageDetails = XposedHelpers.getObjectField(objMessage, fieldMessageKey);
         var messageKey = (String) XposedHelpers.getObjectField(fieldMessageDetails, "A01");
         var stripJID = stripJID(getJidAuthor(objMessage));
@@ -57,7 +55,7 @@ public class XAntiRevoke extends XHookBase {
             Collections.addAll(messageRevokedList, currentRevokedMessages);
         }
         if (messageRevokedList != null && messageRevokedList.contains(messageKey)) {
-            var antirevokeValue = mPref.getInt(antirevokeType, 0);
+            var antirevokeValue = prefs.getInt(antirevokeType, 0);
             if (antirevokeValue == 1) {
                 // Text
                 var newTextData = mApp.getString(stringId) + " | " + dateTextView.getText();
@@ -194,7 +192,7 @@ public class XAntiRevoke extends XHookBase {
         String stripJID = stripJID(getJidAuthor(objMessage));
         try {
             String revokedsString = mShared.getString(stripJID + "_revoked", "");
-            if (revokedsString.equals("")) {
+            if (revokedsString.isEmpty()) {
                 return null;
             } else return StringToStringArray(revokedsString);
         } catch (Exception e) {
@@ -207,7 +205,7 @@ public class XAntiRevoke extends XHookBase {
         try {
             return (str.contains("@g.us") || str.contains("@s.whatsapp.net") || str.contains("@broadcast")) ? str.substring(0, str.indexOf("@")) : str;
         } catch (Exception e) {
-            e.printStackTrace();
+            XposedBridge.log(e.getMessage());
             return str;
         }
     }

--- a/app/src/main/java/its/madruga/wpp/xposed/plugins/functions/XMediaQuality.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/plugins/functions/XMediaQuality.java
@@ -6,10 +6,10 @@ import static its.madruga.wpp.ClassesReference.MediaQuality.imethod;
 import static its.madruga.wpp.ClassesReference.MediaQuality.iparam1;
 import static its.madruga.wpp.ClassesReference.MediaQuality.vClassQuality;
 import static its.madruga.wpp.ClassesReference.MediaQuality.vMethodResolution;
-import static its.madruga.wpp.ClassesReference.MediaQuality.vmethod;
-import static its.madruga.wpp.ClassesReference.MediaQuality.vmethod2;
 import static its.madruga.wpp.ClassesReference.MediaQuality.vParam1;
 import static its.madruga.wpp.ClassesReference.MediaQuality.vParam2;
+import static its.madruga.wpp.ClassesReference.MediaQuality.vmethod;
+import static its.madruga.wpp.ClassesReference.MediaQuality.vmethod2;
 
 import android.util.Pair;
 
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XC_MethodReplacement;
 import de.robv.android.xposed.XSharedPreferences;
-import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import its.madruga.wpp.xposed.models.XHookBase;
 
@@ -29,9 +28,10 @@ public class XMediaQuality extends XHookBase {
 
     @Override
     public void doHook() {
-        boolean videoquality = prefs != null ? prefs.getBoolean("videoquality", false) : false;
-        boolean imagequality = prefs != null ? prefs.getBoolean("imagequality", false) : false;
-        if (videoquality) {
+        var videoQuality = prefs.getBoolean("videoquality", false);
+        var imageQuality = prefs.getBoolean("imagequality", false);
+
+        if (videoQuality) {
             XposedHelpers.findAndHookMethod(vClassQuality, loader, vMethodResolution, int.class, int.class, int.class, new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) throws Throwable {
@@ -54,7 +54,8 @@ public class XMediaQuality extends XHookBase {
                 }
             });
         }
-        if (imagequality) {
+
+        if (imageQuality) {
             var iqClass = findClass(imainClass, loader);
             XposedHelpers.findAndHookMethod(iqClass, imethod, findClass(iparam1, loader), iqClass, int.class, new XC_MethodHook() {
                 @Override

--- a/app/src/main/java/its/madruga/wpp/xposed/plugins/privacy/XGhostMode.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/plugins/privacy/XGhostMode.java
@@ -19,8 +19,10 @@ public class XGhostMode extends XHookBase {
     public void doHook() {
         Class<?> class1 = XposedHelpers.findClass(param1, loader);
         Class<?> class2 = XposedHelpers.findClass(param2, loader);
-        boolean ghostmode = prefs != null ? prefs.getBoolean("ghostmode", false) : false;
+
+        var ghostmode = prefs.getBoolean("ghostmode", false);
         if (!ghostmode) return;
+
         XposedHelpers.findAndHookMethod(class1, ClassesReference.GhostMode.methodName, class1, class2, int.class, new XC_MethodReplacement() {
             @Override
             protected Object replaceHookedMethod(MethodHookParam param) {

--- a/app/src/main/java/its/madruga/wpp/xposed/plugins/privacy/XHideTag.java
+++ b/app/src/main/java/its/madruga/wpp/xposed/plugins/privacy/XHideTag.java
@@ -16,8 +16,10 @@ public class XHideTag extends XHookBase {
 
     @Override
     public void doHook() {
-        boolean hidetag = prefs != null ? prefs.getBoolean("hidetag", false) : false;
-        if (!hidetag) return;
+        var hidetag = prefs.getBoolean("hidetag", false);
+        if (!hidetag)
+            return;
+
         XposedHelpers.findAndHookMethod(classMessageInfo, loader, methodSetForward, int.class, new XC_MethodHook() {
             @Override
             protected void beforeHookedMethod(MethodHookParam param) throws Throwable {


### PR DESCRIPTION
### Description
1. Due to `XSharedPreferences::reload` being an expensive function in a SELinux-enforced device, creating a new instance every time `getPref` is called is not a good idea.
2. Adding `@NonNull` in `XHookBase` helped reduce some lines and contribute to the safety codebase.
3. I also extract some long functions into separate functions to ensure readability, such as `getAsn1TaggedObject` and `getAsn1OctetString`.